### PR TITLE
Add auto dark mode

### DIFF
--- a/web/pages/post.tsx
+++ b/web/pages/post.tsx
@@ -59,7 +59,14 @@ function PostPage() {
           remarkPlugins={[remarkMath]}
           rehypePlugins={[rehypeKatex]}
           components={{
-            code({ node, inline, className, children, style, ...props }) {
+            a({ children, ...props }) {
+              return (
+                <a className={styles.link} {...props}>
+                  {children}
+                </a>
+              );
+            },
+            code({ inline, className, children, style, ...props }) {
               const [, language] = /language-(\w+)/.exec(className || "") || [];
 
               if (inline) {

--- a/web/styles/Home.module.css
+++ b/web/styles/Home.module.css
@@ -19,18 +19,20 @@
 
 .link {
   margin: 6px;
-  color: black;
+  color: var(--boxed-text-color);
 }
 
-.shadow {
-  box-shadow: -4px 4px black;
-}
-
-.shadow-animation {
-  transition: box-shadow 0.3s;
-}
-
-.shadow-animation:hover {
-  box-shadow: -4px 4px black;
-  transition: box-shadow 0.3s;
+@media (prefers-color-scheme: light) {
+  .shadow {
+    box-shadow: -4px 4px black;
+  }
+  
+  .shadow-animation {
+    transition: box-shadow 0.3s;
+  }
+  
+  .shadow-animation:hover {
+    box-shadow: -4px 4px black;
+    transition: box-shadow 0.3s;
+  }
 }

--- a/web/styles/Post.module.css
+++ b/web/styles/Post.module.css
@@ -18,3 +18,7 @@
   padding: 0 4px;
   border-radius: 4px;
 }
+
+.link {
+  color: var(--boxed-text-color);
+}

--- a/web/styles/Post.module.css
+++ b/web/styles/Post.module.css
@@ -2,8 +2,19 @@
   justify-content: center;
 }
 
+@media (prefers-color-scheme: dark) {
+  .inline-code {
+    background-color: #757575;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  .inline-code {
+    background-color: #e9e9e9;
+  }
+}
+
 .inline-code {
-  background-color: #e9e9e9;
   padding: 0 4px;
   border-radius: 4px;
 }

--- a/web/styles/Posts.module.css
+++ b/web/styles/Posts.module.css
@@ -7,7 +7,7 @@
 }
 
 .link {
-  color: black;
+  color: var(--boxed-text-color);
 }
 
 .title {

--- a/web/styles/global.css
+++ b/web/styles/global.css
@@ -1,8 +1,22 @@
 @import url('https://fonts.googleapis.com/css?family=JetBrains+Mono:regular,bold,italic&subset=latin,latin-ext');
 
+:root {
+  --bg:  #6f9d6d;
+  --boxed-text-bg: #fff;
+  --boxed-text-color: #000;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #303030;
+    --boxed-text-bg: #505050;
+    --boxed-text-color: #fff;
+  }
+}
+
 body {
   font-family: 'JetBrains Mono', mono;
-  background-color: #6f9d6d;
+  background-color: var(--bg);
 }
 
 .container {
@@ -16,10 +30,11 @@ body {
 }
 
 .boxed-text {
+  color: var(--boxed-text-color);
   width: fit-content;
   margin: 12px auto;
   max-width: 100%;
   padding: 6px 12px;
-  background-color: white;
+  background-color: var(--boxed-text-bg);
   border-radius: 6px;
 }


### PR DESCRIPTION
Leverage the `prefers-color-scheme` CSS media query to automatically switch site themes based on the user's user-agent